### PR TITLE
Exit Client start-server thread gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __pycache__/
 .idea/
 
 /fre_instance
+/instance
 
 
 # C extensions
@@ -157,3 +158,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+server_output.txt

--- a/app.py
+++ b/app.py
@@ -587,11 +587,15 @@ def start_server_process():
             print(output.strip())
             time.sleep(30)
             client_config.server_ready = True
+        elif client_config.server_tombstone:
+            return
+
 
           
 @app.route('/sim_server_up')
 @login_required
 def sim_server_up():
+    client_config.server_tombstone = False
     server_thread = threading.Thread(target=(start_server_process))
     server_thread.start()
     
@@ -612,6 +616,7 @@ def sim_server_down():
             return error_page("Fail in connecting to server")
 
         client_config.receiver_stop = False
+        client_config.server_tombstone = True
         client_config.client_receiver = threading.Thread(target=client_receive, args=(trading_queue, trading_event))
         client_config.client_receiver.start()
 
@@ -626,14 +631,16 @@ def sim_server_down():
             print("Server down confirmed!")
             client_config.client_socket.close()
 
-        output = os.popen('wmic process get description, processid').read()
-        target_process = "python"
-        for line in output.splitlines():
-            line = line.strip()
-            if target_process in str(line):
-                pid = int(line.split(' ', 1)[1].strip())
-                if pid not in process_list:
-                    os.kill(pid, 9)
+
+        with os.popen("wmic process get description, processid") as process_desc:
+            output = process_desc.read()
+            target_process = "python"
+            for line in output.splitlines():
+                line = line.strip()
+                if target_process in str(line):
+                    pid = int(line.split(' ', 1)[1].strip())
+                    if pid not in process_list:
+                        os.kill(pid, 9)
 
         client_config.server_ready = False
         client_config.client_thread_started = False

--- a/system/utility/config.py
+++ b/system/utility/config.py
@@ -27,6 +27,8 @@ class ClientConfig:
         self.client_up = False
         self.client_symbols = "AAPL,XOM"
 
+        self.server_tombstone = True
+
 
 class ServerConfig:
     def __init__(self):


### PR DESCRIPTION
start_server_process couldn't exit previously. Add a global flag instructs it to exit itself. 