### PR TITLE
Enhancement on Symbol/Ticker Uppercase

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,7 +242,7 @@ def get_quote():
 @login_required
 def buy():
     if request.method == "POST":
-        symbol = request.form.get('symbol')
+        symbol = request.form.get('symbol').upper()
         if not symbol:
             flash('ERROR! Symbol can not be blank.', 'error')
             return render_template("buy.html")
@@ -319,7 +319,7 @@ def buy():
 @login_required
 def sell():
     if request.method == "POST":
-        symbol = request.form.get('symbol')
+        symbol = request.form.get('symbol').upper()
         if not symbol:
             flash('ERROR! Symbol can not be blank.', 'error')
             return render_template("sell.html")
@@ -369,7 +369,7 @@ def sell():
             price = quote["bidPrice"]
         # Sell at input price
         else:
-            price = float(input_price)
+            price = float(input_price.lstrip('$'))
             if not price > 0:
                 flash('ERROR! Price must be positive.', 'error')
                 return render_template("sell.html")
@@ -401,7 +401,7 @@ def sell():
 @login_required
 def short():
     if request.method == "POST":
-        symbol = request.form.get('symbol')
+        symbol = request.form.get('symbol').upper()
         if not symbol:
             flash('ERROR! Symbol can not be blank.', 'error')
             return render_template("short.html")

--- a/system/templates/quote.html
+++ b/system/templates/quote.html
@@ -50,7 +50,7 @@
 
 			<tbody>
 			<tr>
-				<td>{{dict['symbol']}}</td>
+				<td>{{dict['symbol'].upper()}}</td>
 				<td>{{dict['bidPrice']|usd}}</td>
 				<td>{{dict['bidSize']}}</td>
 				<td>{{dict['askPrice']|usd}}</td>


### PR DESCRIPTION
Change the Ticker to uppercase whenever user input symbol is lower case
in Manual Trading. Made Price input strip $ from the string, previously
this was throwing error.