### PR TITLE
Fix SimTrading bugs

### DIFF
--- a/system/sim_trading/sim_demo_model.py
+++ b/system/sim_trading/sim_demo_model.py
@@ -17,7 +17,9 @@ eod_market_data = EODMarketData(os.environ.get("EOD_API_KEY"), database)
 # Stock Info class based on Bollinger Bands Trading Strategy
 class BollingerBandsStocksInfo:    
     def __init__(self, ticker, h=20, k1=2, notional=10000,
-                 price_queue=Queue(int(20 / 5)), ):
+                 price_queue=None):
+        if price_queue is None:
+            price_queue = Queue(int(h/5))
         self.ticker = ticker
         self.h = h
         self.k1 = k1


### PR DESCRIPTION
In SimTrading there're two bugs, fixed the price queue in sim_demo_model
the 4 tickers are sharing the price queue; corrected it to each ticker
has its own price queue so MA and std are calculating correctly.

Also fixed the filled_orderid so it's split based on the ticker, otherwise,
the price for different tickers would be mixed up. #164 